### PR TITLE
remove tooltip icon when empty

### DIFF
--- a/apps/web/src/components/tracker.tsx
+++ b/apps/web/src/components/tracker.tsx
@@ -83,7 +83,7 @@ export function Tracker({
       <div className="mb-1 flex justify-between text-sm sm:mb-2">
         <div className="flex items-center gap-2">
           <p className="text-foreground font-semibold">{name}</p>
-          <MoreInfo {...{ url, id, context, description }} />
+          { description ? <MoreInfo {...{ url, id, context, description }} /> : null }
         </div>
         <p className="text-muted-foreground font-light">{uptime}</p>
       </div>


### PR DESCRIPTION
Currently the tooltip is hoverable but then nothing shows up if I didn't add a description

![CleanShot 2023-08-12 at 18 59 35@2x](https://github.com/chronark/openstatus/assets/18246773/e61a30e4-7d68-4159-9278-d884853344ec)
